### PR TITLE
Adding simple security realm tests

### DIFF
--- a/auth-authz/pom.xml
+++ b/auth-authz/pom.xml
@@ -165,6 +165,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-realm-ldap</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-sasl</artifactId>
       <scope>test</scope>
     </dependency>
@@ -227,6 +232,38 @@
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
         <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.directory.api</groupId>
+      <artifactId>api-ldap-codec-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.directory.api</groupId>
+      <artifactId>api-ldap-extras-codec-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.directory.jdbm</groupId>
+      <artifactId>apacheds-jdbm1</artifactId>
+      <type>jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.directory.server</groupId>
+      <artifactId>apacheds-core-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.directory.server</groupId>
+      <artifactId>apacheds-core-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.directory.server</groupId>
+      <artifactId>apacheds-protocol-ldap</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/auth-authz/pom.xml
+++ b/auth-authz/pom.xml
@@ -160,6 +160,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-realm-jdbc</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-sasl</artifactId>
       <scope>test</scope>
     </dependency>
@@ -216,6 +221,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>org.hsqldb</groupId>
+        <artifactId>hsqldb</artifactId>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/AbstractAuthenticationSuite.java
+++ b/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/AbstractAuthenticationSuite.java
@@ -6,6 +6,7 @@
 package org.wildfly.security.tests.authauthz;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -66,10 +67,18 @@ public abstract class AbstractAuthenticationSuite {
     private static String mode = "";
 
     @AfterSuite
-    public static void endSuite() {
+    public static void endSuite() throws IOException {
         //TODO - Can we handle all clean up on our own?
         System.out.printf("endSuite() called for mode='%s'\n", mode);
         testContext = null;
+        if (streamServer != null) {
+            streamServer.close();
+            streamServer = null;
+        }
+        if (endpoint != null) {
+            endpoint.close();
+            streamServer = null;
+        }
     }
 
     static void setMode(final String mode) {
@@ -115,8 +124,8 @@ public abstract class AbstractAuthenticationSuite {
     }
 
     /**
-     * Create the test server process backed bu the {@code SecurityRealm} available from the
-     * {@code securityRealmSupplier}
+     * Create the test server process backed by the {@code SecurityRealm} available from the
+     * {@code securityRealmSupplier}.
      *
      * @param securityRealmSupplier The supplier of the {@code SecurityRealm}.
      */

--- a/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/FileSystemSecurityRealmTest.java
+++ b/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/FileSystemSecurityRealmTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.security.tests.authauthz;
+
+import static org.wildfly.security.tests.authauthz.AbstractAuthenticationSuite.TEST_PROVIDERS;
+import static org.wildfly.security.tests.authauthz.AbstractAuthenticationSuite.createTestServer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.platform.suite.api.BeforeSuite;
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.realm.FileSystemSecurityRealm;
+import org.wildfly.security.auth.server.ModifiableRealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+/**
+ * A {@code Suite} instance for testing against a {@code SecurityRealm} backed by file system.
+ */
+public class FileSystemSecurityRealmTest extends AbstractAuthenticationSuite {
+
+    private static final Path REALM_DIR = Paths.get("tests-files").toAbsolutePath()
+            .resolve(FileSystemSecurityRealmTest.class.getSimpleName());
+
+    private static PasswordFactory passwordFactory;
+
+    @BeforeSuite
+    public static void setup() throws Exception {
+        registerProvider();
+        passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR, TEST_PROVIDERS);
+        setMode("FILESYSTEM");
+
+        Set<String> supportedMechanims = new HashSet<>();
+        Collections.addAll(supportedMechanims, "PLAIN");
+
+        createTestServer(FileSystemSecurityRealmTest::createSecurityRealm,
+                Collections.unmodifiableSet(supportedMechanims));
+    }
+
+    static SecurityRealm createSecurityRealm() {
+        FileSystemSecurityRealm realm = FileSystemSecurityRealm.builder()
+                .setRoot(REALM_DIR)
+                .build();
+
+        obtainTestIdentities().forEach(identity -> {
+            ModifiableRealmIdentity realmIdentity = realm.getRealmIdentityForUpdate(new NamePrincipal(identity.username()));
+            try {
+                realmIdentity.create();
+                realmIdentity.setCredentials(Collections.singleton(new PasswordCredential(toPassword(identity.password()))));
+                realmIdentity.dispose();
+            } catch (RealmUnavailableException ex) {
+                throw new IllegalStateException("Unable to initialize " + FileSystemSecurityRealmTest.class.getName(), ex);
+            }
+        });
+
+        return realm;
+    }
+
+    static Password toPassword(final String password) {
+        try {
+            return passwordFactory.generatePassword(new ClearPasswordSpec(password.toCharArray()));
+        } catch (InvalidKeySpecException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/JaasSecurityRealmTest.java
+++ b/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/JaasSecurityRealmTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.security.tests.authauthz;
+
+import static org.wildfly.security.tests.authauthz.AbstractAuthenticationSuite.createTestServer;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.platform.suite.api.AfterSuite;
+import org.junit.platform.suite.api.BeforeSuite;
+import org.wildfly.security.auth.realm.JaasSecurityRealm;
+import org.wildfly.security.auth.server.SecurityRealm;
+
+/**
+ * A {@code Suite} instance for testing against a {@code SecurityRealm} backed by a JAAS {@code LoginModule}.
+ */
+public class JaasSecurityRealmTest extends AbstractAuthenticationSuite {
+
+    @BeforeSuite
+    public static void setup() throws Exception {
+        System.setProperty("java.security.auth.login.config", JaasSecurityRealmTest.class.getResource("jaas-login.config").toString());
+        registerProvider();
+        setMode("JAAS");
+
+        Set<String> supportedMechanims = new HashSet<>();
+        Collections.addAll(supportedMechanims, "PLAIN");
+
+        createTestServer(JaasSecurityRealmTest::createSecurityRealm,
+                Collections.unmodifiableSet(supportedMechanims));
+    }
+
+    @AfterSuite
+    public static void cleanup() {
+        System.clearProperty("java.security.auth.login.config");
+    }
+
+    static SecurityRealm createSecurityRealm() {
+        return new JaasSecurityRealm("JaasEntry");
+    }
+}

--- a/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/JdbcSecurityRealmTest.java
+++ b/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/JdbcSecurityRealmTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.security.tests.authauthz;
+
+import static org.wildfly.security.tests.authauthz.AbstractAuthenticationSuite.createTestServer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.platform.suite.api.BeforeSuite;
+import org.wildfly.security.auth.realm.jdbc.JdbcSecurityRealm;
+import org.wildfly.security.auth.realm.jdbc.mapper.PasswordKeyMapper;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.password.interfaces.ClearPassword;
+
+/**
+ * A {@code Suite} instance for testing against a {@code SecurityRealm} backed by a database.
+ */
+public class JdbcSecurityRealmTest extends AbstractAuthenticationSuite {
+
+    private static JDBCDataSource dataSource;
+
+    @BeforeSuite
+    public static void setup() throws Exception {
+        registerProvider();
+        setMode("JDBC");
+
+        Set<String> supportedMechanims = new HashSet<>();
+        Collections.addAll(supportedMechanims, "PLAIN");
+
+        createDataSource();
+
+        createTestServer(JdbcSecurityRealmTest::createSecurityRealm,
+                Collections.unmodifiableSet(supportedMechanims));
+    }
+
+    static SecurityRealm createSecurityRealm() {
+        PasswordKeyMapper passwordKeyMapper = PasswordKeyMapper.builder()
+                .setDefaultAlgorithm(ClearPassword.ALGORITHM_CLEAR)
+                .setHashColumn(1)
+                .build();
+        JdbcSecurityRealm realm = JdbcSecurityRealm.builder()
+                .principalQuery("SELECT password FROM jdbc_realm_users WHERE username = ?")
+                .withMapper(passwordKeyMapper)
+                .from(dataSource)
+                .build();
+        return realm;
+    }
+
+    private static void createDataSource() throws SQLException {
+        dataSource = new JDBCDataSource();
+        dataSource.setDatabase("mem:jdbc-security-realm-test");
+        dataSource.setUser("sa");
+        createUsersTable();
+        insertUsers();
+    }
+
+    private static void createUsersTable() throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+
+            statement.executeUpdate("DROP TABLE IF EXISTS jdbc_realm_users");
+            statement.executeUpdate("CREATE TABLE jdbc_realm_users (username VARCHAR(50), password VARCHAR(50), PRIMARY KEY(username))");
+        }
+    }
+
+    private static void insertUsers() throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement("INSERT INTO jdbc_realm_users (username, password) VALUES (?, ?)")) {
+
+            for (IdentityDefinition identity : obtainTestIdentities().toList()) {
+                statement.setString(1, identity.username());
+                statement.setString(2, identity.password());
+                statement.executeUpdate();
+            }
+        }
+    }
+}

--- a/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/LdapSecurityRealmTest.java
+++ b/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/LdapSecurityRealmTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.security.tests.authauthz;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+import static org.wildfly.security.tests.authauthz.AbstractAuthenticationSuite.createTestServer;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.platform.suite.api.AfterSuite;
+import org.junit.platform.suite.api.BeforeSuite;
+import org.wildfly.security.auth.realm.ldap.DirContextFactory;
+import org.wildfly.security.auth.realm.ldap.LdapSecurityRealmBuilder;
+import org.wildfly.security.auth.realm.ldap.SimpleDirContextFactoryBuilder;
+import org.wildfly.security.auth.server.SecurityRealm;
+
+/**
+ * A {@code Suite} instance for testing against a {@code SecurityRealm} backed by an LDAP.
+ */
+public class LdapSecurityRealmTest extends AbstractAuthenticationSuite {
+
+    static final String SERVER_DN = "uid=server,dc=security,dc=wildfly,dc=org";
+    static final String SERVER_CREDENTIAL = "serverPassword";
+    static final int LDAP_PORT = 11390;
+
+    private static final Path LDAP_DIR = Paths.get("tests-files").toAbsolutePath()
+            .resolve(LdapSecurityRealmTest.class.getSimpleName()).resolve("ldap");
+
+    private static LdapService ldapService;
+
+    @BeforeSuite
+    public static void setup() throws Exception {
+        registerProvider();
+        setMode("LDAP");
+
+        Set<String> supportedMechanims = new HashSet<>();
+        Collections.addAll(supportedMechanims, "PLAIN");
+
+        createLdap();
+
+        createTestServer(LdapSecurityRealmTest::createSecurityRealm,
+                Collections.unmodifiableSet(supportedMechanims));
+    }
+
+    @AfterSuite
+    public static void stopLdap() throws IOException {
+        ldapService.close();
+    }
+
+    static SecurityRealm createSecurityRealm() {
+        LdapSecurityRealmBuilder builder = LdapSecurityRealmBuilder.builder()
+                .setDirContextSupplier(() -> SimpleDirContextFactoryBuilder.builder()
+                    .setProviderUrl(String.format("ldap://localhost:%d/", LDAP_PORT))
+                    .setSecurityPrincipal(SERVER_DN)
+                    .setSecurityCredential(SERVER_CREDENTIAL)
+                    .build().obtainDirContext(DirContextFactory.ReferralMode.IGNORE))
+                .identityMapping()
+                    .setSearchDn("dc=security,dc=wildfly,dc=org")
+                    .setRdnIdentifier("uid")
+                    .build()
+                .userPasswordCredentialLoader().build();
+        return builder.build();
+    }
+
+    private static void createLdap() throws Exception {
+        StringBuilder identitiesString = new StringBuilder();
+        obtainTestIdentities().forEach(identity -> {
+            identitiesString.append(String.format("dn: uid=%s,dc=security,dc=wildfly,dc=org\n", identity.username()));
+            identitiesString.append("objectClass: top\nobjectClass: inetOrgPerson\nobjectClass: person\nobjectClass: organizationalPerson\n");
+            identitiesString.append(String.format("cn: %s\n", identity.username()));
+            identitiesString.append(String.format("sn: %s\n", identity.username()));
+            identitiesString.append(String.format("uid: %s\n", identity.username()));
+            identitiesString.append(String.format("userPassword:: %s\n\n", Base64.getEncoder().encodeToString(identity.password().getBytes())));
+        });
+
+        ldapService = LdapService.builder()
+                .setWorkingDir(LDAP_DIR.toFile())
+                .createDirectoryService(LdapSecurityRealmTest.class.getSimpleName())
+                .addPartition("Elytron", "dc=security,dc=wildfly,dc=org", 5, "uid")
+                .importLdif(LdapSecurityRealmTest.class.getResourceAsStream("ldap-security-realm-test.ldif"))
+                .importLdif(new ByteArrayInputStream(identitiesString.toString().getBytes()))
+                .addTcpServer("Default TCP", "localhost", LDAP_PORT)
+                .start();
+    }
+}

--- a/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/LdapService.java
+++ b/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/LdapService.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.security.tests.authauthz;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.server.core.api.CoreSession;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.api.partition.Partition;
+import org.apache.directory.server.core.factory.DefaultDirectoryServiceFactory;
+import org.apache.directory.server.core.factory.DirectoryServiceFactory;
+import org.apache.directory.server.core.factory.PartitionFactory;
+import org.apache.directory.server.ldap.LdapServer;
+import org.apache.directory.server.protocol.shared.transport.TcpTransport;
+import org.apache.directory.server.protocol.shared.transport.Transport;
+
+/**
+ * Wrapper around ApacheDS.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class LdapService implements Closeable {
+
+    private final DirectoryService directoryService;
+    private final Collection<LdapServer> servers;
+
+    private LdapService(final DirectoryService directoryService, final Collection<LdapServer> servers) {
+        this.directoryService = directoryService;
+        this.servers = servers;
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (LdapServer current : servers) {
+            current.stop();
+        }
+        try {
+            directoryService.shutdown();
+        } catch (LdapException e) {
+            throw new IOException("Unable to shut down DirectoryService", e);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private boolean started = false;
+        private File workingDir = null;
+        private DirectoryServiceFactory directoryServiceFactory;
+        private DirectoryService directoryService;
+        private final List<LdapServer> servers = new LinkedList<LdapServer>();
+
+        Builder() {
+        }
+
+        /**
+         * Set the working dir that will be used by the directory server.
+         *
+         * WARNING - Any contents in this directory will be deleted.
+         *
+         * @param workingDir - The working dir for the directory server to use.
+         * @return This Builder for subsequent changes.
+         */
+        public Builder setWorkingDir(final File workingDir) {
+            assertNotStarted();
+
+            this.workingDir = workingDir;
+
+            return this;
+        }
+
+        /**
+         * Create the core directory service.
+         *
+         * @param name - The name of the directory service.
+         * @return This Builder for subsequent changes.
+         */
+        public Builder createDirectoryService(final String name) throws Exception {
+            if (directoryService != null) {
+                throw new IllegalStateException("Directory service already created.");
+            }
+
+            initWorkingDir();
+
+            directoryServiceFactory = new DefaultDirectoryServiceFactory();
+            directoryServiceFactory.init(name);
+
+            DirectoryService directoryService = directoryServiceFactory.getDirectoryService();
+
+            directoryService.getChangeLog().setEnabled(false);
+
+            this.directoryService = directoryService;
+
+            return this;
+        }
+
+        /**
+         * Add a new partition to the directory server.
+         *
+         * @param id the partition id
+         * @param partitionName - The name of the partition.
+         * @param indexSize cache size
+         * @param indexes - The attributes to index.
+         * @return This Builder for subsequent changes.
+         */
+        public Builder addPartition(final String id, final String partitionName, final int indexSize, final String ... indexes) throws Exception {
+            assertNotStarted();
+            if (directoryService == null) {
+                throw new IllegalStateException("The Directory service has not been created.");
+            }
+
+            SchemaManager schemaManager = directoryService.getSchemaManager();
+            PartitionFactory partitionFactory = directoryServiceFactory.getPartitionFactory();
+            Partition partition = partitionFactory.createPartition(schemaManager, directoryService.getDnFactory(), id, partitionName, 1000, workingDir);
+            for (String current : indexes) {
+                partitionFactory.addIndex(partition, current, indexSize);
+            }
+            partition.initialize();
+            directoryService.addPartition(partition);
+
+            return this;
+        }
+
+        /**
+         * Import all of the entries from the provided LDIF stream.
+         *
+         * Note: The whole stream is read and closed then.
+         *
+         * @param ldif - Stream containing the LDIF.
+         * @return This Builder for subsequent changes.
+         */
+        public Builder importLdif(final InputStream ldif) throws Exception {
+            assertNotStarted();
+            if (directoryService == null) {
+                throw new IllegalStateException("The Directory service has not been created.");
+            }
+            CoreSession adminSession = directoryService.getAdminSession();
+            SchemaManager schemaManager = directoryService.getSchemaManager();
+
+            try (LdifReader ldifReader = new LdifReader(ldif)) {
+                for (LdifEntry ldifEntry : ldifReader) {
+                    adminSession.add(new DefaultEntry(schemaManager, ldifEntry.getEntry()));
+                }
+            }
+            ldif.close();
+
+            return this;
+        }
+
+        /**
+         * Adds a TCP server to the directory service. SSL/TLS is not enabled.
+         *
+         * Note: The TCP server is not started until start() is called on this Builder.
+         *
+         * @param serviceName - The name of this server.
+         * @param hostName - The host name to listen on.
+         * @param port - The port to listen on.
+         * @return This Builder for subsequent changes.
+         */
+        public Builder addTcpServer(final String serviceName, final String hostName, final int port) throws URISyntaxException {
+            assertNotStarted();
+            if (directoryService == null) {
+                throw new IllegalStateException("The Directory service has not been created.");
+            }
+
+            LdapServer server = new LdapServer();
+            server.setServiceName(serviceName);
+            Transport ldap = new TcpTransport( hostName, port, 3, 5 );
+            server.addTransports(ldap);
+            server.setDirectoryService(directoryService);
+
+            servers.add(server);
+
+            return this;
+        }
+
+        /**
+         * Adds a TCP server to the directory service. SSL/TLS is enabled.
+         *
+         * Note: The TCP server is not started until start() is called on this Builder.
+         *
+         * @param serviceName - The name of this server.
+         * @param hostName - The host name to listen on.
+         * @param port - The port to listen on.
+         * @param keyStore key store with server certificate
+         * @param keyStorePassword password to the key store
+         * @return This Builder for subsequent changes.
+         */
+        public Builder addTcpServer(final String serviceName, final String hostName, final int port, final String keyStore, final String keyStorePassword) throws URISyntaxException {
+            assertNotStarted();
+            if (directoryService == null) {
+                throw new IllegalStateException("The Directory service has not been created.");
+            }
+
+            LdapServer server = new LdapServer();
+            server.setServiceName(serviceName);
+            Transport ldaps = new TcpTransport( hostName, port, 3, 5 );
+            ldaps.enableSSL(true);
+            server.addTransports(ldaps);
+            server.setKeystoreFile(new File(getClass().getResource(keyStore).getFile()).getAbsolutePath());
+            server.setCertificatePassword(keyStorePassword);
+            server.setDirectoryService(directoryService);
+
+            servers.add(server);
+
+            return this;
+        }
+
+        public LdapService start() throws Exception {
+            assertNotStarted();
+            started = true;
+
+            for (LdapServer current : servers) {
+                current.start();
+            }
+
+            return new LdapService(directoryService, servers);
+        }
+
+        private void assertNotStarted() {
+            if (started) {
+                throw new IllegalStateException("Already started.");
+            }
+        }
+
+        private void initWorkingDir() {
+            if (workingDir == null) {
+                throw new IllegalStateException("No working dir.");
+            }
+
+            if (workingDir.exists() == false) {
+                if (workingDir.mkdirs() == false) {
+                    throw new IllegalStateException("Unable to create working dir.");
+                }
+            }
+            emptyDir(workingDir);
+        }
+
+        private void emptyDir(final File dir) {
+            for (File current : dir.listFiles()) {
+                if (current.delete() == false) {
+                    try {
+                        throw new IllegalStateException(String.format("Unable to delete file '%s' from working dir '%s'.",
+                                current.getName(), workingDir.getCanonicalPath()));
+                    } catch (IOException e) {
+                        throw new IllegalStateException(e);
+                    }
+                }
+            }
+        }
+
+    }
+
+}
+

--- a/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/PropertiesSecurityRealmTest.java
+++ b/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/PropertiesSecurityRealmTest.java
@@ -5,7 +5,15 @@
 
 package org.wildfly.security.tests.authauthz;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.platform.suite.api.BeforeSuite;
+import org.wildfly.security.auth.realm.LegacyPropertiesSecurityRealm;
+import org.wildfly.security.auth.server.SecurityRealm;
+import static org.wildfly.security.tests.authauthz.AbstractAuthenticationSuite.createTestServer;
 
 /**
  * A {@code Suite} instance for testing against a {@code SecurityRealm} backed by a properties file.
@@ -15,8 +23,31 @@ import org.junit.platform.suite.api.BeforeSuite;
 public class PropertiesSecurityRealmTest extends AbstractAuthenticationSuite {
 
     @BeforeSuite
-    public static void setup() {
+    public static void setup() throws Exception {
+        registerProvider();
         setMode("PROPERTIES");
+
+        Set<String> supportedMechanims = new HashSet<>();
+        Collections.addAll(supportedMechanims, "PLAIN");
+
+        createTestServer(PropertiesSecurityRealmTest::createSecurityRealm,
+                Collections.unmodifiableSet(supportedMechanims));
     }
 
+    static SecurityRealm createSecurityRealm() {
+        StringBuilder identitiesString = new StringBuilder();
+        obtainTestIdentities().forEach(identity -> {
+            identitiesString.append(String.format("%s=%s\n", identity.username(), identity.password()));
+        });
+        try {
+            LegacyPropertiesSecurityRealm realm = LegacyPropertiesSecurityRealm.builder()
+                    .setPlainText(true)
+                    .setUsersStream(new ByteArrayInputStream(identitiesString.toString().getBytes()))
+                    .build();
+
+            return realm;
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to initialize " + PropertiesSecurityRealmTest.class.getName(), ex);
+        }
+    }
 }

--- a/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/TestJaasLoginModule.java
+++ b/auth-authz/src/test/java/org/wildfly/security/tests/authauthz/TestJaasLoginModule.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.security.tests.authauthz;
+
+import static org.wildfly.security.tests.authauthz.AbstractAuthenticationSuite.obtainTestIdentities;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+/**
+ * A JAAS {@link LoginModule} backed by a {@link Map}.
+ * Users are initialized from {@link AbstractAuthenticationSuite#obtainTestIdentities}.
+ */
+public class TestJaasLoginModule implements LoginModule {
+
+    private final Map<String, char[]> identities = new HashMap<>();
+    private Subject subject;
+    private CallbackHandler callbackHandler;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.subject = subject;
+        this.callbackHandler = callbackHandler;
+        obtainTestIdentities().forEach(identity -> {
+            this.identities.put(identity.username(), identity.password().toCharArray());
+        });
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        NameCallback nameCallback = new NameCallback("Username");
+        PasswordCallback passwordCallback = new PasswordCallback("Password", false);
+        Callback[] callbacks = new Callback[] {nameCallback, passwordCallback};
+        try {
+            this.callbackHandler.handle(callbacks);
+        } catch(UnsupportedCallbackException | IOException e) {
+            throw new LoginException("Callback handling failed: " + e.getMessage());
+        }
+
+        String username = nameCallback.getName();
+        char[] password = passwordCallback.getPassword();
+        char[] passwordInModule = this.identities.get(username);
+
+        return password != null && username != null && Arrays.equals(passwordInModule, password);
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        this.subject.getPrincipals().clear();
+        return true;
+    }
+}

--- a/auth-authz/src/test/resources/org/wildfly/security/tests/authauthz/jaas-login.config
+++ b/auth-authz/src/test/resources/org/wildfly/security/tests/authauthz/jaas-login.config
@@ -1,0 +1,3 @@
+JaasEntry {
+    org.wildfly.security.tests.authauthz.TestJaasLoginModule required;
+};

--- a/auth-authz/src/test/resources/org/wildfly/security/tests/authauthz/ldap-security-realm-test.ldif
+++ b/auth-authz/src/test/resources/org/wildfly/security/tests/authauthz/ldap-security-realm-test.ldif
@@ -1,0 +1,17 @@
+version: 1
+
+dn: dc=security,dc=wildfly,dc=org
+objectclass: top
+objectclass: domain
+dc: security
+
+dn: uid=server,dc=security,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+cn: server
+sn: server
+uid: server
+userPassword:: c2VydmVyUGFzc3dvcmQ=
+# Password serverPassword

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -32,6 +32,7 @@
   <name>wildfly-security-testsuite-bom</name>
 
   <properties>
+    <version.org.hsqldb>2.7.4</version.org.hsqldb>
     <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.logmanager.jboss-logmanager>2.1.19.Final</version.org.jboss.logmanager.jboss-logmanager>
     <version.org.jboss.remoting>5.0.31.Final</version.org.jboss.remoting>
@@ -44,6 +45,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.hsqldb</groupId>
+        <artifactId>hsqldb</artifactId>
+        <version>${version.org.hsqldb}</version>
+      </dependency>
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
@@ -289,6 +295,17 @@
       <dependency>
         <groupId>org.wildfly.security</groupId>
         <artifactId>wildfly-elytron-realm</artifactId>
+        <version>${version.org.wildfly.elytron}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.security</groupId>
+        <artifactId>wildfly-elytron-realm-jdbc</artifactId>
         <version>${version.org.wildfly.elytron}</version>
         <exclusions>
           <exclusion>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -32,6 +32,9 @@
   <name>wildfly-security-testsuite-bom</name>
 
   <properties>
+    <version.org.apache.directory.api>2.1.7</version.org.apache.directory.api>
+    <version.org.apache.directory.jdbm>2.0.0-M3</version.org.apache.directory.jdbm>
+    <version.org.apache.directory.server>2.0.0.AM27</version.org.apache.directory.server>
     <version.org.hsqldb>2.7.4</version.org.hsqldb>
     <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.logmanager.jboss-logmanager>2.1.19.Final</version.org.jboss.logmanager.jboss-logmanager>
@@ -45,6 +48,53 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.directory.api</groupId>
+        <artifactId>api-ldap-codec-standalone</artifactId>
+        <version>${version.org.apache.directory.api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.api</groupId>
+        <artifactId>api-ldap-extras-codec-api</artifactId>
+        <version>${version.org.apache.directory.api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.jdbm</groupId>
+        <artifactId>apacheds-jdbm1</artifactId>
+        <type>jar</type>
+        <version>${version.org.apache.directory.jdbm}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.server</groupId>
+        <artifactId>apacheds-core-annotations</artifactId>
+        <version>${version.org.apache.directory.server}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.directory.jdbm</groupId>
+            <artifactId>apacheds-jdbm1</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.server</groupId>
+        <artifactId>apacheds-core-api</artifactId>
+        <version>${version.org.apache.directory.server}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.server</groupId>
+        <artifactId>apacheds-protocol-ldap</artifactId>
+        <version>${version.org.apache.directory.server}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.directory.jdbm</groupId>
+            <artifactId>apacheds-jdbm1</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
@@ -306,6 +356,17 @@
       <dependency>
         <groupId>org.wildfly.security</groupId>
         <artifactId>wildfly-elytron-realm-jdbc</artifactId>
+        <version>${version.org.wildfly.elytron}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.security</groupId>
+        <artifactId>wildfly-elytron-realm-ldap</artifactId>
         <version>${version.org.wildfly.elytron}</version>
         <exclusions>
           <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <workingDirectory>${project.build.directory}</workingDirectory>
           <systemProperties>
             <property>
               <name>java.util.logging.manager</name>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
             </property>
           </systemProperties>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+              <disable>false</disable>
+              <version>3.0.2</version>
+              <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+          </statelessTestsetReporter>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Adding simple security realm tests (using PLAIN mechanism) for file system, JAAS, JDBC, LDAP, and properties security realms.